### PR TITLE
Add requestAnimationFrame animation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # animation-js
+
+## Running the example
+
+1. Create an `index.html` file in the project root with the following content:
+
+```html
+<!doctype html>
+<html>
+  <body>
+    <canvas id="canvas" width="300" height="100"></canvas>
+    <script type="module" src="src/example.js"></script>
+  </body>
+</html>
+```
+
+2. Open the file directly in a browser or serve it locally (e.g. `npx serve .`) and navigate to the page.
+3. You should see a red square move across the canvas.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 ```html
 <!doctype html>
-<html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>requestAnimationFrame example</title>
+  </head>
   <body>
     <canvas id="canvas" width="300" height="100"></canvas>
     <script type="module" src="src/example.js"></script>

--- a/src/example.js
+++ b/src/example.js
@@ -1,0 +1,13 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let x = 0;
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'red';
+  ctx.fillRect(x, 10, 50, 50);
+  x = (x + 2) % canvas.width;
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);


### PR DESCRIPTION
## Summary
- add canvas animation using `requestAnimationFrame`
- document how to run the example

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689668cbbac88320a318c774c3172c53